### PR TITLE
Fix for issue, "Nickname bug"

### DIFF
--- a/prj/chat/server.c
+++ b/prj/chat/server.c
@@ -130,60 +130,6 @@ int main(int argc , char *argv[])
                     client_socket[i] = new_socket;
                     client_socket_init[i] = new_socket;
                     printf("Adding to list of init sockets as %d\n" , i);
-                    
-                    /*
-                      here it is some bug - server hungs while client enter his nick - need to fix
-                      ideas: 1) to move read nick block to send message block
-                             2) to use fork() and to left all nicking job on son
-                             3) to create alarm() signal and to kick client, if he entering nick too long
-                    */
-                    /*
-                    char sym;
-
-                    for   (k = 0; k < MAXNICK; ++k ) 
-                     if ( (valread = read( new_socket, &sym, 1 )) == 0 || sym == '\n' || sym == ' ') break; 
-                     else
-                     {
-                        client_name[i][k] = sym;
-                        write(1,&sym,1); //cout nick to server log
-                     } 
-                        write(1,"\n",1); 
-                    
-                    if ( k == 0 || valread == 0 || sym == ' ')
-                    {
-                       //end of file - somebody disconnected | empty nick 
-                       
-                       if ( sym == ' ')
-                            message = "kicked: nickname with spaces\n";
-                       else if (k)
-                            message = "kicked: empty nickname\n";
-                       else 
-                            message = "\ndisconected\n";
-                       send(new_socket, message, strlen(message), 0); 
-
-                       getpeername(new_socket , (struct sockaddr*)&address , (socklen_t*)&addrlen); //address of peer connected from sd
-                       printf("Host disconnected , ip : %s , port : %d , name : %s\n" , 
-                            inet_ntoa(address.sin_addr) , ntohs(address.sin_port) , client_name[i]);
-                     
-                       shutdown( new_socket ,2); // close connection
-                       close( new_socket );
-                       client_socket[i] = 0;
-                       strcpy(client_name[i], "\0");
-                    }
-                    else //nick entered right
-                    {
-                        message = " joined the chat!\n\0";
-                        strncpy(mes,client_name[i],k);
-                        mes[k] = '\0';
-                        strcat(mes,message);
-                        for (k = 0; k < max_clients; k++) //send join info
-                        {
-                            if (client_socket[k] == 0) continue;
-                            sd = client_socket[k]; 
-                            send(sd , mes , strlen(mes) , 0 );
-                        }
-                    }
-                    */
                     break;
                 }
             }

--- a/prj/chat/server.c
+++ b/prj/chat/server.c
@@ -128,6 +128,7 @@ int main(int argc , char *argv[])
                 if( client_socket[i] == 0 )
                 {
                     client_socket[i] = new_socket;
+                    //add socket to init list
                     client_socket_init[i] = new_socket;
                     printf("Adding to list of init sockets as %d\n" , i);
                     break;
@@ -164,7 +165,7 @@ int main(int argc , char *argv[])
                     shutdown(sd,2); // close connection
                     close( sd );
                     client_socket[i] = 0;
-                    if(sd_is_init) client_socket_init[i] = 0;;
+                    if(sd_is_init) client_socket_init[i] = 0; //remove socket from init list
                     message = " left the chat!\n\0";
                     for(k = 0; k < MAXNICK; ++k) //length of nick
                         if ( client_name[i][k] == '\n' || client_name[i][k] == '\0' )
@@ -194,7 +195,7 @@ int main(int argc , char *argv[])
                             shutdown( sd ,2); // close connection
                             close( sd );
                             client_socket[i] = 0;
-                            client_socket_init[i] = 0;
+                            client_socket_init[i] = 0; //remove socket from init list
                             strcpy(client_name[i], "\0");
                             continue;
                         }
@@ -209,7 +210,7 @@ int main(int argc , char *argv[])
                                 shutdown( sd ,2); // close connection
                                 close( sd );
                                 client_socket[i] = 0;
-                                client_socket_init[i] = 0;
+                                client_socket_init[i] = 0; //remove socket from init list
                                 strcpy(client_name[i], "\0");
                                 break;
                             }
@@ -228,6 +229,7 @@ int main(int argc , char *argv[])
                             send(client_socket[k] , mes , strlen(mes) , 0 );
                         }
 
+                        //remove socket from init list
                         client_socket_init[i] = 0;
                     }
                     else


### PR DESCRIPTION
A potential fix for the bug which caused the server to hang when a new user is entering nickname.

All blocking read() on the server side is done in one place which is called if there is data available on a socket. This is achieved by putting new incoming user sockets to a new additional list of initial sockets. When user has sent nickname and nick name is OK the socket is removed from the initial list.